### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main # or main, or any other branch where you are releasing
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/alexbypa/CSharp.Essentials/security/code-scanning/1](https://github.com/alexbypa/CSharp.Essentials/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the minimal permissions required. Based on the workflow's steps, the `contents: read` permission is sufficient for most operations, while the `packages: write` permission is required for publishing the NuGet package. This ensures that the `GITHUB_TOKEN` has only the necessary permissions to complete the tasks in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
